### PR TITLE
Update to use brew golang builder

### DIFF
--- a/.tekton/maestro-addon-main-pull-request.yaml
+++ b/.tekton/maestro-addon-main-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: Dockerfile
+    value: Containerfile.konflux
   - name: git-url
     value: '{{source_url}}'
   - name: image-expires-after

--- a/.tekton/maestro-addon-main-push.yaml
+++ b/.tekton/maestro-addon-main-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: Dockerfile
+    value: Containerfile.konflux
   - name: git-url
     value: '{{source_url}}'
   - name: output-image

--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -1,0 +1,35 @@
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+
+ENV SOURCE_DIR=/maestro-addon
+WORKDIR $SOURCE_DIR
+COPY . $SOURCE_DIR
+
+ENV GOFLAGS=""
+RUN make binary
+RUN pwd
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+RUN \
+    microdnf update -y \
+    && \
+    microdnf install -y util-linux \
+    && \
+    microdnf clean all
+
+COPY --from=builder \
+    /maestro-addon/maestro-addon \
+    /usr/local/bin/
+
+EXPOSE 8000
+
+ENTRYPOINT ["/usr/local/bin/maestro-addon", "serve"]
+
+LABEL name="maestro-addon" \
+      vendor="Red Hat, Inc." \
+      version="0.0.1" \
+      summary="maestro ACM addon" \
+      description="maestro ACM addon" \
+      io.k8s.description="maestro ACM addon" \
+      io.k8s.display-name="maestro-addon" \
+      io.openshift.tags="maestro-addon"

--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -20,12 +20,8 @@ RUN \
     microdnf clean all
 
 COPY --from=builder \
-    /maestro-addon/maestro-addon \
+    /maestro-addon/maestroaddon \
     /usr/local/bin/
-
-EXPOSE 8000
-
-ENTRYPOINT ["/usr/local/bin/maestro-addon", "serve"]
 
 LABEL name="maestro-addon" \
       vendor="Red Hat, Inc." \

--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -5,7 +5,9 @@ WORKDIR $SOURCE_DIR
 COPY . $SOURCE_DIR
 
 ENV GOFLAGS=""
-RUN make binary
+RUN GOOS=${OS} \
+    GOARCH=${ARCH} \
+    make build --warn-undefined-variables
 RUN pwd
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest

--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.21 AS builder
 
 ENV SOURCE_DIR=/maestro-addon
 WORKDIR $SOURCE_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.21-linux AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
 
 ARG OS=linux
 ARG ARCH=amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.21 AS builder
 
 ARG OS=linux
 ARG ARCH=amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.21 AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.21-linux AS builder
 
 ARG OS=linux
 ARG ARCH=amd64


### PR DESCRIPTION
## Summary

This PR updates maestro-addon to use the brew registry golang-builder as a base!